### PR TITLE
chore: bump rust to 1.79.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # rust-release-playground
-123456
+1234567


### PR DESCRIPTION
<!--
List the issues this PR closes (if any) in a bullet list format, e.g.:
- Closes #ABCD
- Closes #EFGH
-->

# Release notes

In this release, we:

- Bumped up the rust bersion

# Summary

Needed for https://github.com/FuelLabs/fuels-rs/pull/1462 to use path::absolute from Rust 1.79.
This will be the MSRV for the next 6+ months.

# Checklist

- [x] All **changes** are **covered** by **tests** (or not applicable)
- [x] All **changes** are **documented** (or not applicable)
- [x] I **reviewed** the **entire PR** myself (preferably, on GH UI)
- [x] I **described** all **Breaking Changes** (or there's none)